### PR TITLE
Add Animated Percentage Panels

### DIFF
--- a/capstone/fitness/src/main/java/com/google/sps/servlets/PanelServlet.java
+++ b/capstone/fitness/src/main/java/com/google/sps/servlets/PanelServlet.java
@@ -1,0 +1,99 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+import com.google.sps.fit.*;
+import com.google.sps.progress.*;
+import com.google.sps.util.*;
+import java.io.IOException;
+import java.util.*;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/panels")
+public class PanelServlet extends HttpServlet {
+
+  private static final String SESSION = "Last Session";
+  private static final String NEXT_STEP = "Next Step";
+  private static final String GOAL = "Goal";
+  private static final String VIEWING_STEP = "Viewing Step";
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    String goalStepsJson = DataHandler.getGoalSteps();
+    List<JsonExercise> panelDisplay = Collections.emptyList();
+    if(goalStepsJson != null) {
+      ProgressModel model = new ProgressModel.Builder()
+                            .setJsonGoalSteps(goalStepsJson)
+                            .build();
+      HttpSession session = request.getSession();
+      Integer insertion = (Integer) session.getAttribute("insertion");
+      GoalStep viewing = insertion == null ? null : model.toArray()[insertion];
+      panelDisplay = getPanelItems(DataHandler.getLastSession(), model.getCurrentMainGoalStep(), model.getLast(), viewing);
+    }
+    response.setContentType("application/json");
+    response.getWriter().println(getJson(panelDisplay));
+  }
+
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    HttpSession session = request.getSession();
+    session.setAttribute("insertion", updateInsertion(request));
+    response.sendRedirect("/progress.html");
+  }
+
+  private List<JsonExercise> getPanelItems(Session session, GoalStep next, GoalStep goal, GoalStep viewing) {
+    List<JsonExercise> exercises = new ArrayList<>();
+    // Do not get extra info if there's no session.
+    if(session == null) {
+      return exercises;
+    }
+
+    // Add last session exercises.
+    for(Exercise e : session.getWorkout()) {
+      exercises.add(new JsonExercise(SESSION, e));
+    }
+
+    // Add panel comparison exercises.
+    exercises.add(new JsonExercise(NEXT_STEP, next));
+    exercises.add(new JsonExercise(GOAL, goal));
+    if(viewing != null) {
+      exercises.add(new JsonExercise(VIEWING_STEP, viewing));
+    }
+    
+    return exercises;
+  }
+
+  private String getJson(List<JsonExercise> panelDisplay) {
+    Gson gson = new Gson();
+    String json = gson.toJson(panelDisplay);
+    return json;
+  }
+
+  private Integer updateInsertion(HttpServletRequest request) {
+    // Insertion index refers to actual index of step being viewed in viewing panel.
+    String insertionString = request.getParameter("insertion");
+    if(insertionString != null  && !insertionString.isEmpty()) {
+      int parsedInsertion = Integer.parseInt(insertionString);
+      return parsedInsertion < 0 ? null : parsedInsertion;
+    }
+    return null;
+  }
+}

--- a/capstone/fitness/src/main/java/com/google/sps/servlets/ProgressPanelServlet.java
+++ b/capstone/fitness/src/main/java/com/google/sps/servlets/ProgressPanelServlet.java
@@ -28,7 +28,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 @WebServlet("/panels")
-public class PanelServlet extends HttpServlet {
+public class ProgressPanelServlet extends HttpServlet {
 
   private static final String SESSION = "Last Session";
   private static final String NEXT_STEP = "Next Step";

--- a/capstone/fitness/src/main/webapp/progress.html
+++ b/capstone/fitness/src/main/webapp/progress.html
@@ -81,7 +81,7 @@
           </div>
         </div>
       </div>
-      <div class="row">
+      <div id="view-panel" class="row">
         <!-- Viewing -->
         <div class="mb-4 col-sm-6">
           <div class="bg-white rounded p-5 shadow">

--- a/capstone/fitness/src/main/webapp/progress.html
+++ b/capstone/fitness/src/main/webapp/progress.html
@@ -14,6 +14,9 @@
   <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/paginationjs/2.1.5/pagination.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/paginationjs/2.1.5/pagination.js"></script>
+  <script src="https://cdn.tutorialjinni.com/progressbar.js/1.1.0/progressbar.js"></script>
+  <script src="https://cdn.tutorialjinni.com/progressbar.js/1.1.0/progressbar.min.js"></script>
+  <script src="https://cdn.tutorialjinni.com/progressbar.js/1.1.0/progressbar.min.js.map"></script>
   <script src="progress_disp.js"></script>
 </head>
 
@@ -62,77 +65,29 @@
     <div class="col-sm-8" style="color: black;">
       <div class="row">
         <!-- Current -->
-        <!--TODO(ijelue): Add Servlet and javascript to get percentages and versus values. -->
         <div class="mb-4 col-sm-6">
           <div class="bg-white rounded p-5 shadow">
             <h2 class="font-weight-bold text-center mb-4">Distance From The Next Step</h2>
-            <div class="progress mx-auto" data-value='66.7'>
-              <span class="progress-left"><span class="progress-bar border-primary"></span></span>
-              <span class="progress-right"><span class="progress-bar border-primary"></span></span>
-              <div class="progress-value w-100 h-100 rounded-circle d-flex align-items-center justify-content-center">
-                <div class="h2 font-weight-bold">66.7<sup class="small">%</sup></div>
-              </div>
-            </div>
-            <div class="row text-center mt-4">
-              <div class="col-6 border-right">
-                <div class="font-weight-bold mb-0">5 km/hr</div>
-                <span class="small text-gray">Last Session</span>
-              </div>
-              <div class="col-6">
-                <div class="font-weight-bold mb-0">7.5 km/hr</div>
-                <span class="small text-gray">Step</span>
-              </div>
-            </div>
+            <div id="next-bar"></div>
+            <div id="next-sets"></div>
           </div>
         </div>
         <!-- Goal -->
-        <!--TODO(ijelue): Add Servlet and javascript to get percentages and versus values. -->
         <div class="mb-4 col-sm-6">
           <div class="bg-white rounded p-5 shadow">
             <h2 class="font-weight-bold text-center mb-4">Distance From Your Goal</h2>
-            <div class="progress mx-auto" data-value='50'>
-              <span class="progress-left"><span class="progress-bar border-primary"></span></span>
-                <span class="progress-right"><span class="progress-bar border-primary"></span></span>
-                <div class="progress-value w-100 h-100 rounded-circle d-flex align-items-center justify-content-center">
-                  <div class="h2 font-weight-bold">50<sup class="small">%</sup></div>
-                </div>
-            </div>
-            <div class="row text-center mt-4">
-              <div class="col-6 border-right">
-                <div class="font-weight-bold mb-0">5 km/hr</div>
-                <span class="small text-gray">Last Session</span>
-              </div>
-              <div class="col-6">
-                <div class="font-weight-bold mb-0">10 km/hr</div>
-                <span class="small text-gray">Goal</span>
-              </div>
-            </div>
+            <div id="goal-bar"></div>
+            <div id="goal-sets"></div>
           </div>
         </div>
       </div>
       <div class="row">
         <!-- Viewing -->
-        <!--TODO(ijelue): Add Servlet and javascript to get percentages and versus values (when hovering or pressing goal step button, this container shows up). -->
         <div class="mb-4 col-sm-6">
           <div class="bg-white rounded p-5 shadow">
-          <h2 class="font-weight-bold text-center mb-4">Distance From Step N</h2>
-            <div class="progress mx-auto" data-value='62.5'>
-              <span class="progress-left"><span class="progress-bar border-primary"></span></span>
-              <span class="progress-right"><span class="progress-bar border-primary"></span></span>
-              <div class="progress-value w-100 h-100 rounded-circle d-flex align-items-center justify-content-center">
-                <div class="h2 font-weight-bold">62.5<sup class="small">%</sup></div>
-              </div>
-            </div>
-            <div class="row text-center mt-4">
-              <div class="col-6 border-right">
-                <div class="font-weight-bold mb-0">5 km/hr</div>
-                <span class="small text-gray">Last Session</span>
-              </div>
-              <div class="col-6">
-                <div class="font-weight-bold mb-0">8 km/hr</div>
-                <span class="small text-gray">Step</span>
-              </div>
-            </div>
+            <h2 id="view-panel-header" class="font-weight-bold text-center mb-4"></h2>
+            <div id="viewing-bar"></div>
+            <div id="viewing-sets"></div>
           </div>
         </div>
       </div>

--- a/capstone/fitness/src/main/webapp/style.css
+++ b/capstone/fitness/src/main/webapp/style.css
@@ -34,11 +34,6 @@ body {
   margin: 0 10px;
 }
 
-/*
-  Progress Styling. 
-  Code Snippet taken from https://jsfiddle.net/bootstrapious/3xnomecr.
-*/
-
 .goal-desc-insertion {
   border-left: 2px solid black;
   height: 25%;
@@ -56,68 +51,6 @@ body {
 .progress {
   background: none;
   height: 150px;
-  position: relative;
+  margin: auto;
   width: 150px;
-}
-
-.progress::after {
-  border: 6px solid #eee;
-  border-radius: 50%;
-  content: "";
-  height: 100%;
-  left: 0;
-  position: absolute;
-  top: 0;
-  width: 100%;
-}
-
-.progress>span {
-  height: 100%;
-  overflow: hidden;
-  position: absolute;
-  top: 0;
-  width: 50%;
-  z-index: 1;
-}
-
-.progress .progress-left {
-  left: 0;
-}
-
-.progress .progress-bar {
-  background: none;
-  border-style: solid;
-  border-width: 6px;
-  height: 100%;
-  position: absolute;
-  top: 0;
-  width: 100%;
-}
-
-.progress .progress-left .progress-bar {
-  border-bottom-right-radius: 80px;
-  border-left: 0;
-  border-top-right-radius: 80px;
-  left: 100%;
-  transform-origin: center left;
-  -webkit-transform-origin: center left;
-}
-
-.progress .progress-right {
-  right: 0;
-}
-
-.progress .progress-right .progress-bar {
-  border-bottom-left-radius: 80px;
-  border-right: 0;
-  border-top-left-radius: 80px;
-  left: -100%;
-  transform-origin: center right;
-  -webkit-transform-origin: center right;
-}
-
-.progress .progress-value {
-  left: 0;
-  position: absolute;
-  top: 0;
 }


### PR DESCRIPTION
Add:
- PanelServlet.java; gets the goal steps that we want to compare to each exercise in the latest session (next goal step, final goal step, and viewing goal step).
![image](https://user-images.githubusercontent.com/23709028/91237134-7445c580-e6ff-11ea-947d-ca89d7cc7afb.png)
![image](https://user-images.githubusercontent.com/23709028/91237206-99d2cf00-e6ff-11ea-9fa8-7f231e8835c9.png)

Update:
- Remove old template percentage code and bootstrap styling in favor of existing progress bar library.

**Note**: Will work on styling with pod mates (size, color, etc).